### PR TITLE
Add `bytes` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,11 @@ path = "src/lib.rs"
 [features]
 default = []
 serde = ["dep:serde"]
+bytes = ["dep:bytes"]
 
 [dependencies]
 byteorder = "1.5.0"
+bytes = { version = "1.8.0", optional = true }
 log = "0.4.22"
 min-max-heap = "1.3.0"
 path-absolutize = "3.1.1"
@@ -36,6 +38,7 @@ criterion = "0.5.1"
 rand = "0.8.5"
 test-log = "0.2.16"
 lz4_flex = { version = "0.11.3" }
+bytes = { version = "1.8.0" }
 
 [[bench]]
 name = "value_log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ criterion = "0.5.1"
 rand = "0.8.5"
 test-log = "0.2.16"
 lz4_flex = { version = "0.11.3" }
-bytes = { version = "1.8.0" }
 
 [[bench]]
 name = "value_log"

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -15,6 +15,12 @@ pub use slice_arc::Slice;
 #[cfg(feature = "bytes")]
 pub use slice_bytes::Slice;
 
+impl AsRef<[u8]> for Slice {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl From<&[u8]> for Slice {
     fn from(value: &[u8]) -> Self {
         Self::new(value)

--- a/src/slice/slice_arc.rs
+++ b/src/slice/slice_arc.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+use std::sync::Arc;
+
+/// An immutable byte slice that can be cloned without additional heap allocation
+#[derive(Debug, Clone, Eq, Hash, Ord)]
+pub struct Slice(Arc<[u8]>);
+
+impl Slice {
+    /// Construct a [`Slice`] from a byte slice.
+    #[must_use]
+    pub fn new(bytes: &[u8]) -> Self {
+        Self::from(bytes)
+    }
+
+    #[must_use]
+    #[doc(hidden)]
+    pub fn with_size(len: usize) -> Self {
+        // TODO: optimize this with byteview to remove the reallocation
+        let v = vec![0; len];
+        Self(v.into())
+    }
+
+    #[doc(hidden)]
+    pub fn from_reader<R: std::io::Read>(reader: &mut R, len: usize) -> std::io::Result<Self> {
+        let mut view = Self::with_size(len);
+        let builder = Arc::get_mut(&mut view.0).expect("we are the owner");
+        reader.read_exact(builder)?;
+        Ok(view)
+    }
+}
+
+impl AsRef<[u8]> for Slice {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<&[u8]> for Slice {
+    fn from(value: &[u8]) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Arc<[u8]>> for Slice {
+    fn from(value: Arc<[u8]>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Vec<u8>> for Slice {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&str> for Slice {
+    fn from(value: &str) -> Self {
+        Self::from(value.as_bytes())
+    }
+}
+
+impl From<String> for Slice {
+    fn from(value: String) -> Self {
+        Self::from(value.as_bytes())
+    }
+}
+
+impl From<Arc<str>> for Slice {
+    fn from(value: Arc<str>) -> Self {
+        Self::from(&*value)
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Slice {
+    fn from(value: [u8; N]) -> Self {
+        Self::from(value.as_slice())
+    }
+}
+
+impl FromIterator<u8> for Slice {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = u8>,
+    {
+        Vec::from_iter(iter).into()
+    }
+}
+
+impl std::ops::Deref for Slice {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<[u8]> for Slice {
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
+impl<T> PartialEq<T> for Slice
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl PartialEq<Slice> for &[u8] {
+    fn eq(&self, other: &Slice) -> bool {
+        *self == other.as_ref()
+    }
+}
+
+impl<T> PartialOrd<T> for Slice
+where
+    T: AsRef<[u8]> + ?Sized,
+{
+    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+        self.as_ref().partial_cmp(other.as_ref())
+    }
+}
+
+impl PartialOrd<Slice> for &[u8] {
+    fn partial_cmp(&self, other: &Slice) -> Option<std::cmp::Ordering> {
+        (*self).partial_cmp(other.as_ref())
+    }
+}

--- a/src/slice/slice_arc.rs
+++ b/src/slice/slice_arc.rs
@@ -12,7 +12,7 @@ impl Slice {
     /// Construct a [`Slice`] from a byte slice.
     #[must_use]
     pub fn new(bytes: &[u8]) -> Self {
-        Self::from(bytes)
+        Self(bytes.into())
     }
 
     #[must_use]
@@ -38,97 +38,23 @@ impl AsRef<[u8]> for Slice {
     }
 }
 
-impl From<&[u8]> for Slice {
-    fn from(value: &[u8]) -> Self {
-        Self(value.into())
+// Arc::from<Vec<T>> is specialized
+impl From<Vec<u8>> for Slice {
+    fn from(value: Vec<u8>) -> Self {
+        Self(Arc::from(value))
     }
 }
 
+// Arc::from<Vec<T>> is specialized
+impl From<String> for Slice {
+    fn from(value: String) -> Self {
+        Self(Arc::from(value.into_bytes()))
+    }
+}
+
+// direct conversion
 impl From<Arc<[u8]>> for Slice {
     fn from(value: Arc<[u8]>) -> Self {
         Self(value)
-    }
-}
-
-impl From<Vec<u8>> for Slice {
-    fn from(value: Vec<u8>) -> Self {
-        Self(value.into())
-    }
-}
-
-impl From<&str> for Slice {
-    fn from(value: &str) -> Self {
-        Self::from(value.as_bytes())
-    }
-}
-
-impl From<String> for Slice {
-    fn from(value: String) -> Self {
-        Self::from(value.as_bytes())
-    }
-}
-
-impl From<Arc<str>> for Slice {
-    fn from(value: Arc<str>) -> Self {
-        Self::from(&*value)
-    }
-}
-
-impl<const N: usize> From<[u8; N]> for Slice {
-    fn from(value: [u8; N]) -> Self {
-        Self::from(value.as_slice())
-    }
-}
-
-impl FromIterator<u8> for Slice {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = u8>,
-    {
-        Vec::from_iter(iter).into()
-    }
-}
-
-impl std::ops::Deref for Slice {
-    type Target = [u8];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::borrow::Borrow<[u8]> for Slice {
-    fn borrow(&self) -> &[u8] {
-        self
-    }
-}
-
-impl<T> PartialEq<T> for Slice
-where
-    T: AsRef<[u8]> + ?Sized,
-{
-    fn eq(&self, other: &T) -> bool {
-        self.as_ref() == other.as_ref()
-    }
-}
-
-impl PartialEq<Slice> for &[u8] {
-    fn eq(&self, other: &Slice) -> bool {
-        *self == other.as_ref()
-    }
-}
-
-impl<T> PartialOrd<T> for Slice
-where
-    T: AsRef<[u8]> + ?Sized,
-{
-    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
-        self.as_ref().partial_cmp(other.as_ref())
-    }
-}
-
-impl PartialOrd<Slice> for &[u8] {
-    fn partial_cmp(&self, other: &Slice) -> Option<std::cmp::Ordering> {
-        (*self).partial_cmp(other.as_ref())
     }
 }

--- a/src/slice/slice_arc.rs
+++ b/src/slice/slice_arc.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 /// An immutable byte slice that can be cloned without additional heap allocation
 #[derive(Debug, Clone, Eq, Hash, Ord)]
-pub struct Slice(Arc<[u8]>);
+pub struct Slice(pub(super) Arc<[u8]>);
 
 impl Slice {
     /// Construct a [`Slice`] from a byte slice.
@@ -29,12 +29,6 @@ impl Slice {
         let builder = Arc::get_mut(&mut view.0).expect("we are the owner");
         reader.read_exact(builder)?;
         Ok(view)
-    }
-}
-
-impl AsRef<[u8]> for Slice {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
     }
 }
 

--- a/src/slice/slice_bytes.rs
+++ b/src/slice/slice_bytes.rs
@@ -1,0 +1,139 @@
+// Copyright (c) 2024-present, fjall-rs
+// This source code is licensed under both the Apache 2.0 and MIT License
+// (found in the LICENSE-* files in the repository)
+
+use std::sync::Arc;
+
+use bytes::{BufMut, Bytes, BytesMut};
+
+/// An immutable byte slice that can be cloned without additional heap allocation
+#[derive(Debug, Clone, Eq, Hash, Ord)]
+pub struct Slice(Bytes);
+
+impl Slice {
+    /// Construct a [`Slice`] from a byte slice.
+    #[must_use]
+    pub fn new(bytes: &[u8]) -> Self {
+        Self::from(bytes)
+    }
+
+    #[doc(hidden)]
+    pub fn from_reader<R: std::io::Read>(reader: &mut R, len: usize) -> std::io::Result<Self> {
+        let mut builder = BytesMut::zeroed(len);
+        reader.read_exact(&mut builder)?;
+        Ok(builder.freeze().into())
+    }
+}
+
+impl AsRef<[u8]> for Slice {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Bytes> for Slice {
+    fn from(value: Bytes) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Slice> for Bytes {
+    fn from(value: Slice) -> Self {
+        value.0
+    }
+}
+
+impl From<&[u8]> for Slice {
+    fn from(value: &[u8]) -> Self {
+        Self(Bytes::copy_from_slice(value))
+    }
+}
+
+impl From<Arc<[u8]>> for Slice {
+    fn from(value: Arc<[u8]>) -> Self {
+        value.as_ref().into()
+    }
+}
+
+impl From<Vec<u8>> for Slice {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<&str> for Slice {
+    fn from(value: &str) -> Self {
+        Self::from(value.as_bytes())
+    }
+}
+
+impl From<String> for Slice {
+    fn from(value: String) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<Arc<str>> for Slice {
+    fn from(value: Arc<str>) -> Self {
+        Self::from(&*value)
+    }
+}
+
+impl<const N: usize> From<[u8; N]> for Slice {
+    fn from(value: [u8; N]) -> Self {
+        Self::from(value.as_slice())
+    }
+}
+
+impl FromIterator<u8> for Slice {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = u8>,
+    {
+        Self(Bytes::from_iter(iter))
+    }
+}
+
+impl std::ops::Deref for Slice {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<[u8]> for Slice {
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
+impl<T> PartialEq<T> for Slice
+where
+    T: AsRef<[u8]>,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl PartialEq<Slice> for &[u8] {
+    fn eq(&self, other: &Slice) -> bool {
+        *self == other.as_ref()
+    }
+}
+
+impl<T> PartialOrd<T> for Slice
+where
+    T: AsRef<[u8]>,
+{
+    fn partial_cmp(&self, other: &T) -> Option<std::cmp::Ordering> {
+        self.as_ref().partial_cmp(other.as_ref())
+    }
+}
+
+impl PartialOrd<Slice> for &[u8] {
+    fn partial_cmp(&self, other: &Slice) -> Option<std::cmp::Ordering> {
+        (*self).partial_cmp(other.as_ref())
+    }
+}

--- a/src/slice/slice_bytes.rs
+++ b/src/slice/slice_bytes.rs
@@ -8,7 +8,7 @@ use bytes::{Bytes, BytesMut};
 
 /// An immutable byte slice that can be cloned without additional heap allocation
 #[derive(Debug, Clone, Eq, Hash, Ord)]
-pub struct Slice(Bytes);
+pub struct Slice(pub(super) Bytes);
 
 impl Slice {
     /// Construct a [`Slice`] from a byte slice.
@@ -22,12 +22,6 @@ impl Slice {
         let mut builder = BytesMut::zeroed(len);
         reader.read_exact(&mut builder)?;
         Ok(builder.freeze().into())
-    }
-}
-
-impl AsRef<[u8]> for Slice {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
     }
 }
 


### PR DESCRIPTION
This feature causes `Slice` to be backed by `bytes::Bytes` rather than `Arc<[u8]>`.

I copied most of the Slice implementation to keep the change simple and testable. I also added tests to ensure compatibility with all the different ways Slices are created and compared. And switched to generics for PartialOrd/PartialEq to make testing easier and the API more complete.

I've run tests on all three projects locally (with/without the feature flag) and the only other changes required are passing through the bytes feature flag, and some lint related errors in lsm-tree. Will submit PRs to both of those projects shortly.

Required for https://github.com/fjall-rs/fjall/issues/94