### PR TITLE
Provide From<ByteView> for Slice construction

### DIFF
--- a/src/slice/slice_default.rs
+++ b/src/slice/slice_default.rs
@@ -56,3 +56,9 @@ impl From<String> for Slice {
         Self(ByteView::from(value.into_bytes()))
     }
 }
+
+impl From<ByteView> for Slice {
+    fn from(value: ByteView) -> Self {
+        Self(value)
+    }
+}


### PR DESCRIPTION
Analogous to From<Bytes> for slice_bytes.rs, to allow for zero-copy operations with existing ByteViews.

https://github.com/fjall-rs/value-log/issues/19