### PR TITLE
Add From<Slice> for ByteView

### DIFF
--- a/src/slice/slice_default.rs
+++ b/src/slice/slice_default.rs
@@ -62,3 +62,9 @@ impl From<ByteView> for Slice {
         Self(value)
     }
 }
+
+impl From<Slice> for ByteView {
+    fn from(value: Slice) -> Self {
+        value.0
+    }
+}


### PR DESCRIPTION
Sorry, missed this in previous PR.

For scenarios when the caller wants to pull the Slice from the ByteView without a copy. Analogous to From<Slice> for Bytes in slice_bytes.rs

