### PR TITLE
relax deny(unsafe_code) rather than removing it entirely

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,8 @@
 #![warn(clippy::expect_used)]
 #![allow(clippy::missing_const_for_fn)]
 #![warn(clippy::multiple_crate_versions)]
-// the bytes feature uses unsafe to improve from_reader performance
+// the bytes feature uses unsafe to improve from_reader performance; so we need to relax this lint
+#![cfg_attr(feature = "bytes", deny(unsafe_code))]
 #![cfg_attr(not(feature = "bytes"), forbid(unsafe_code))]
 
 mod blob_cache;

--- a/src/slice/slice_bytes.rs
+++ b/src/slice/slice_bytes.rs
@@ -47,15 +47,16 @@ impl Slice {
         // SAFETY: we just allocated `len` bytes, and `read_exact` will fail if
         // it doesn't fill the buffer, subsequently dropping the uninitialized
         // BytesMut object
+        #[allow(unsafe_code)]
         unsafe {
             builder.set_len(len);
         }
 
-        /// SAFETY: Normally, read_exact over an uninitialized buffer is UB,
-        /// however we know that in lsm-tree etc. only I/O readers or cursors over Vecs are used
-        /// so it's safe
-        ///
-        /// The safe API is unstable: https://github.com/rust-lang/rust/issues/78485
+        // SAFETY: Normally, read_exact over an uninitialized buffer is UB,
+        // however we know that in lsm-tree etc. only I/O readers or cursors over Vecs are used
+        // so it's safe
+        //
+        // The safe API is unstable: https://github.com/rust-lang/rust/issues/78485
         reader.read_exact(&mut builder)?;
 
         Ok(Self(builder.freeze()))


### PR DESCRIPTION
also fix a lint warning on doc comments