### PR TITLE
Impl Error::source

### DIFF
--- a/src/coding.rs
+++ b/src/coding.rs
@@ -11,6 +11,32 @@ pub enum EncodeError {
     Io(std::io::Error),
 }
 
+impl std::fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "EncodeError({})",
+            match self {
+                Self::Io(e) => e.to_string(),
+            }
+        )
+    }
+}
+
+impl From<std::io::Error> for EncodeError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl std::error::Error for EncodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+        }
+    }
+}
+
 /// Error during deserialization
 #[derive(Debug)]
 pub enum DecodeError {
@@ -26,15 +52,31 @@ pub enum DecodeError {
     InvalidHeader(&'static str),
 }
 
-impl From<std::io::Error> for EncodeError {
-    fn from(value: std::io::Error) -> Self {
-        Self::Io(value)
+impl std::fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "DecodeError({})",
+            match self {
+                Self::Io(e) => e.to_string(),
+                e => format!("{e:?}"),
+            }
+        )
     }
 }
 
 impl From<std::io::Error> for DecodeError {
     fn from(value: std::io::Error) -> Self {
         Self::Io(value)
+    }
+}
+
+impl std::error::Error for DecodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,18 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::InvalidVersion(_) => None,
+            Self::Encode(e) => Some(e),
+            Self::Decode(e) => Some(e),
+            Self::Compress => None,
+            Self::Decompress => None,
+        }
+    }
+}
 
 impl From<std::io::Error> for Error {
     fn from(value: std::io::Error) -> Self {


### PR DESCRIPTION
By implementing Error::source, it allows a user to extract io::Errors without importing all fjall crates and manually spidering Fjall's error enums.