### PR TITLE
perf: allow setting compression to None

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ impl<BC: BlobCache, C: Compressor + Clone + Default> Config<BC, C> {
     pub fn new(blob_cache: BC) -> Self {
         Self {
             blob_cache,
-            compression: Default::default(),
+            compression: None,
             segment_size_bytes: 128 * 1_024 * 1_024,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,7 @@ pub struct Config<BC: BlobCache, C: Compressor + Clone> {
     pub(crate) blob_cache: BC,
 
     /// Compression to use
-    pub(crate) compression: C,
+    pub(crate) compression: Option<C>,
 }
 
 impl<BC: BlobCache, C: Compressor + Clone + Default> Config<BC, C> {
@@ -28,7 +28,7 @@ impl<BC: BlobCache, C: Compressor + Clone + Default> Config<BC, C> {
 
     /// Sets the compression & decompression scheme.
     #[must_use]
-    pub fn compression(mut self, compressor: C) -> Self {
+    pub fn compression(mut self, compressor: Option<C>) -> Self {
         self.compression = compressor;
         self
     }

--- a/src/segment/multi_writer.rs
+++ b/src/segment/multi_writer.rs
@@ -53,9 +53,9 @@ impl<C: Compressor + Clone> MultiWriter<C> {
     /// Sets the compression method
     #[must_use]
     #[doc(hidden)]
-    pub fn use_compression(mut self, compressor: C) -> Self {
-        self.compression = Some(compressor.clone());
-        self.get_active_writer_mut().compression = Some(compressor);
+    pub fn use_compression(mut self, compressor: Option<C>) -> Self {
+        self.compression.clone_from(&compressor);
+        self.get_active_writer_mut().compression = compressor;
         self
     }
 

--- a/src/segment/reader.rs
+++ b/src/segment/reader.rs
@@ -55,8 +55,8 @@ impl<C: Compressor + Clone> Reader<C> {
         }
     }
 
-    pub(crate) fn use_compression(mut self, compressor: C) -> Self {
-        self.compression = Some(compressor);
+    pub(crate) fn use_compression(mut self, compressor: Option<C>) -> Self {
+        self.compression = compressor;
         self
     }
 }

--- a/tests/compression.rs
+++ b/tests/compression.rs
@@ -23,7 +23,10 @@ fn compression() -> value_log::Result<()> {
 
     let index = MockIndex::default();
 
-    let value_log = ValueLog::open(vl_path, Config::<_, Lz4Compressor>::new(NoCacher))?;
+    let value_log = ValueLog::open(
+        vl_path,
+        Config::<_, Lz4Compressor>::new(NoCacher).compression(Some(Lz4Compressor)),
+    )?;
 
     let mut index_writer = MockIndexWriter(index.clone());
     let mut writer = value_log.get_writer()?;


### PR DESCRIPTION
making reader skip memcpy & reallocation