### PR TITLE
Hold write lock during fs remove in gc

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -296,7 +296,10 @@ impl<C: Compressor + Clone> SegmentManifest<C> {
         Ok(())
     }
 
-    fn write_to_disk<P: AsRef<Path>>(path: P, segment_ids: &[SegmentId]) -> crate::Result<()> {
+    pub(crate) fn write_to_disk<P: AsRef<Path>>(
+        path: P,
+        segment_ids: &[SegmentId],
+    ) -> crate::Result<()> {
         let path = path.as_ref();
         log::trace!("Writing segment manifest to {}", path.display());
 


### PR DESCRIPTION
This change holds the segement write lock while we remove stale files from the fs. This resolves a race condition where reads can try to reference files that no longer exist on disk.

Fixes #38 